### PR TITLE
(feat) Support chunked prefill with prefix cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ hip_compat.h
 *.json
 
 scratch/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,5 @@ hip_compat.h
 
 # Benchmark dataset
 *.json
+
+scratch/

--- a/.gitignore
+++ b/.gitignore
@@ -192,4 +192,5 @@ hip_compat.h
 *.json
 
 scratch/
+
 .idea/

--- a/vllm/attention/backends/flashinfer.py
+++ b/vllm/attention/backends/flashinfer.py
@@ -251,6 +251,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         block_tables = inter_data.block_tables
         computed_block_nums = inter_data.computed_block_nums
 
+        if chunked_prefill_enabled and inter_data.prefix_cache_hit:
+            raise RuntimeError(
+                "Chunked prefill and prefix caching cannot be used "
+                "simultaneously with flashinfer backend, try switching "
+                "to flash-attn backend by setting the environment variable "
+                "\"VLLM_ATTENTION_BACKEND=FLASH_ATTN\"")
+
         for (seq_id, token_len, seq_len, curr_seq_len, query_len, context_len,
              curr_sliding_window_block) in zip(
                  inter_data.seq_ids, [len(t) for t in inter_data.input_tokens],

--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -108,6 +108,13 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
         block_tables = inter_data.block_tables
         computed_block_nums = inter_data.computed_block_nums
 
+        if chunked_prefill_enabled and inter_data.prefix_cache_hit:
+            raise RuntimeError(
+                "Chunked prefill and prefix caching can only be used "
+                "simultaneously with flash-attn backend, try switching "
+                "to flash-attn backend by setting the environment variable "
+                "\"VLLM_ATTENTION_BACKEND=FLASH_ATTN\"")
+
         for (seq_id, token_len, seq_len, curr_seq_len, query_len, context_len,
              curr_sliding_window_block) in zip(
                  inter_data.seq_ids, [len(t) for t in inter_data.input_tokens],

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -282,7 +282,8 @@ class Sequence:
 
     @property
     def n_blocks(self) -> int:
-        return math.ceil(self.get_len() / self.block_size)
+        return (self.get_len() + self.block_size - 1) // self.block_size
+        # return math.ceil(self.get_len() / self.block_size)
 
     @property
     def prompt(self) -> Optional[str]:

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -384,7 +384,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                 seq_idx] = inter_data.seq_lens[seq_idx] - context_len
 
 
-def _compute_for_sliding_window(self, inter_data: InterDataForSeqGroup,
+    def _compute_for_sliding_window(self, inter_data: InterDataForSeqGroup,
                                     seq_idx: int,
                                     seq_group_metadata: SequenceGroupMetadata):
         """Update seq_len and curr_sliding_window_block for the given

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -330,25 +330,61 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                             and self.sliding_window is None
                             and inter_data.is_prompt)
         inter_data.prefix_cache_hit = prefix_cache_hit
-        if self.chunked_prefill_enabled and prefix_cache_hit:
-            raise RuntimeError(
-                "chunked prefill cannot be used with prefix caching now.")
+        # if self.chunked_prefill_enabled and prefix_cache_hit:
+        #     raise RuntimeError(
+        #         "chunked prefill cannot be used with prefix caching now.")
 
         # If prefix cache is hit, advance context length to bypass
         # hit blocks. Accordingly, input tokens, position and query length
         # have to be updated.
+        # if prefix_cache_hit:
+        #     assert computed_block_nums is not None
+        #     context_len = len(computed_block_nums) * self.block_size
+        #     inter_data.input_tokens[seq_idx] = inter_data.input_tokens[
+        #         seq_idx][context_len:]
+        #     inter_data.input_positions[seq_idx] = inter_data.input_positions[
+        #         seq_idx][context_len:]
+        #     inter_data.context_lens[seq_idx] = context_len
+        #     inter_data.query_lens[
+        #         seq_idx] = inter_data.seq_lens[seq_idx] - context_len
+
         if prefix_cache_hit:
-            assert computed_block_nums is not None
-            context_len = len(computed_block_nums) * self.block_size
-            inter_data.input_tokens[seq_idx] = inter_data.input_tokens[
-                seq_idx][context_len:]
-            inter_data.input_positions[seq_idx] = inter_data.input_positions[
-                seq_idx][context_len:]
+            prefix_cache_len = len(computed_block_nums) * self.block_size
+            # When prefix caching meets chunked prefill, we would be in
+            # one of the following three cases:
+            context_len = inter_data.context_lens[seq_idx]
+            seq_len = inter_data.seq_lens[seq_idx]
+            if prefix_cache_len <= context_len:
+                # Do normal chunked prefill.
+                pass
+            elif context_len < prefix_cache_len < seq_len:
+                # Advance the context_len to seq_len to prefill non-cached
+                # parts of the prompt.
+                inter_data.input_tokens[seq_idx] = inter_data.input_tokens[
+                                                       seq_idx][(prefix_cache_len - context_len):]
+                inter_data.input_positions[
+                    seq_idx] = inter_data.input_positions[seq_idx][(
+                                                                       prefix_cache_len - context_len):]
+                context_len = prefix_cache_len
+            elif seq_len <= prefix_cache_len:
+                # The current partial sequence is fully cache hit,
+                # and no further computation is needed. In this case,
+                # We leave at least 1 token for chunked prefill to prevent
+                # empty sequences in the attention computation.
+                inter_data.input_tokens[seq_idx] = inter_data.input_tokens[
+                                                       seq_idx][(seq_len - 1 - context_len):]
+                inter_data.input_positions[
+                    seq_idx] = inter_data.input_positions[seq_idx][(
+                                                                       seq_len - 1 - context_len):]
+                context_len = seq_len - 1
+                pass
+
             inter_data.context_lens[seq_idx] = context_len
             inter_data.query_lens[
                 seq_idx] = inter_data.seq_lens[seq_idx] - context_len
 
-    def _compute_for_sliding_window(self, inter_data: InterDataForSeqGroup,
+
+def _compute_for_sliding_window(self, inter_data: InterDataForSeqGroup,
                                     seq_idx: int,
                                     seq_group_metadata: SequenceGroupMetadata):
         """Update seq_len and curr_sliding_window_block for the given


### PR DESCRIPTION
_This PR is a checkpoint of some features we want in our branch._

Support prefix caching with chunked prefill. 

**Testing.** 
- Open 2 vllm server with `--enable-prefix-caching` and `--enable-chunked-prefill`. 
- Compare the output using the same prompt in `api_client.py` and see if they match.

```bash
## Server side
# Round 1: without prefix caching
sh scripts/vllm-server.sh 

# Round 2: with prefix caching
sh scripts/vllm-server.sh --enable-prefix-caching
```